### PR TITLE
fix: fix writeFileSync version compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const sizeOf = require('image-size');
 const chalk = require('chalk');
 const merge = require('lodash/merge');
 
-const { createHTMLDocument, imgToBase64 } = require('./utils');
+const { createHTMLDocument, imgToBase64, blobToBuffer } = require('./utils');
 
 const defaultConfig = {
   /** "table of contents" file path */
@@ -89,11 +89,11 @@ async function run(config) {
     }
 
     const html = createHTMLDocument(htmlArr.join('<br/>'), bodyStyles);
-
-    fs.writeFileSync(
-      pathToPublic,
+    const buffer = await blobToBuffer(
       html2Docx.asBlob(html, { orientation, margins })
     );
+
+    fs.writeFileSync(pathToPublic, buffer);
 
     console.log(
       '\n',
@@ -105,7 +105,7 @@ async function run(config) {
   }
 }
 
-function mdToHtml(options) {
+async function mdToHtml(options) {
   const { rootPath, titleDowngrade, imgMaxWidth, filePath } = options;
   return new Promise((resolve, reject) => {
     fs.readFile(filePath, 'utf8', function (err, file) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,10 +12,18 @@ const createHTMLDocument = (body, bodyStyles) => {
 
 const imgToBase64 = imgPath => {
   let bitmap = fs.readFileSync(imgPath);
-  return 'data:image/png;base64,' + Buffer.from(bitmap, 'binary').toString('base64');
+  return (
+    'data:image/png;base64,' + Buffer.from(bitmap, 'binary').toString('base64')
+  );
 };
+
+async function blobToBuffer(blob) {
+  const arrayBuffer = await blob.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}
 
 module.exports = {
   createHTMLDocument,
-  imgToBase64
+  imgToBase64,
+  blobToBuffer
 };


### PR DESCRIPTION
```
TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Blob
    at Object.writeFileSync (node:fs:2314:5)
    at run (.../node_modules/docsify-docx-converter/src/index.js:89:8) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```